### PR TITLE
Contributor UUID merge

### DIFF
--- a/src/Components/Home.js
+++ b/src/Components/Home.js
@@ -15,9 +15,11 @@ export default function Home(props) {
   let [owner, setOwner] = useState('');
 
   useEffect(() => {
+    //Get repo/owner from current browser window
     chrome.storage.local.get(['repo'], data => setRepo(data.repo));
     chrome.storage.local.get(['owner'], data => setOwner(data.owner));
 
+    //Set current logged in contributor/id to chrome storage for inject to verify user for voting
     chrome.storage.local.set({ contributor_name: user.login });
     chrome.storage.local.set({ contributor_id: user.ethereumAddress });
   });

--- a/src/inject.js
+++ b/src/inject.js
@@ -275,16 +275,17 @@ if (rootcontainer.length) {
     chrome.storage.local.set({ owner: user });
     chrome.storage.local.set({ repo: repo });
 
+    //Check if repo is tokenized
     const res_get_repo_status = await get_repo_status(repo_id);
     const isRepoTurboSrcToken = res_get_repo_status['body']['data']['getRepoStatus'];
 
     //Function to get items from chrome storage set from Extension
     let getFromStorage = keys =>
       new Promise((resolve, reject) => chrome.storage.local.get([keys], result => resolve(result[keys])));
-
+    //Values are set in Extension App, Components/Home.js on render
     contributor_name = await getFromStorage('contributor_name');
     contributor_id = await getFromStorage('contributor_id');
-
+    //Check if current contributor is authorized for this repo
     const res_get_authorized_contributor = await get_authorized_contributor(contributor_id, repo_id);
     const isAuthorizedContributor = res_get_authorized_contributor['body']['data']['getAuthorizedContributor'];
 
@@ -598,16 +599,6 @@ if (rootcontainer.length) {
           return;
         }
 
-        // Get contributor_id from chain web wallet extension
-
-        let getFromStorageContributorName = keys =>
-          new Promise((resolve, reject) =>
-            chrome.storage.local.get(['contributor_name'], result => resolve(result.contributor_name))
-          );
-        contributor_name = await getFromStorageContributorName();
-        console.log('authcontributors');
-        console.log(contributor_name);
-        contributor_id = await postGetContributorID(user, repo, issue_id, contributor_name);
         var html;
         for (var i = startIndex; i < containerItems.length; i++) {
           issue_id = containerItems[i].getAttribute('id');

--- a/src/inject.js
+++ b/src/inject.js
@@ -271,23 +271,20 @@ if (rootcontainer.length) {
     user = path.user;
     var statusReact = await postGetPRvoteStatus(user, repo, issue_id, contributor_id, side);
 
-    storageUtil.set('repo', repo);
-    storageUtil.set('owner', user);
-
+    //Set Github Repo and User from browser window for chrome extension
     chrome.storage.local.set({ owner: user });
     chrome.storage.local.set({ repo: repo });
 
     const res_get_repo_status = await get_repo_status(repo_id);
     const isRepoTurboSrcToken = res_get_repo_status['body']['data']['getRepoStatus'];
-    //contributor_name =  authContributor.getAuthContributor();
-    let getFromStorageContributorName = keys =>
-      new Promise((resolve, reject) =>
-        chrome.storage.local.get(['contributor_name'], result => resolve(result.contributor_name))
-      );
-    contributor_name = await getFromStorageContributorName();
-    console.log('authcontributors');
-    console.log(contributor_name);
-    contributor_id = await postGetContributorID(user, repo, issue_id, contributor_name);
+
+    //Function to get items from chrome storage set from Extension
+    let getFromStorage = keys =>
+      new Promise((resolve, reject) => chrome.storage.local.get([keys], result => resolve(result[keys])));
+
+    contributor_name = await getFromStorage('contributor_name');
+    contributor_id = await getFromStorage('contributor_id');
+
     const res_get_authorized_contributor = await get_authorized_contributor(contributor_id, repo_id);
     const isAuthorizedContributor = res_get_authorized_contributor['body']['data']['getAuthorizedContributor'];
 

--- a/src/inject.js
+++ b/src/inject.js
@@ -38,8 +38,25 @@ var repo_id;
 var issue_id;
 var side;
 var contributor_id;
-var contributor_name
-var voteTotals
+var contributor_name;
+var voteTotals;
+
+// Inform the background page that this tab should have a page-action.
+chrome.runtime.sendMessage({
+  from: 'content',
+  subject: 'showPageAction'
+});
+// Listen for messages from the popup.
+chrome.runtime.onMessage.addListener((msg, sender, response) => {
+  // Message from popup requesting github user info
+  if (msg.from === 'popup' && msg.subject === 'Github User') {
+    var githubUserInfo = {
+      user: document.getElementById('#user').innerText
+    };
+
+    response(githubUserInfo);
+  }
+});
 
 let rootcontainer = document.querySelectorAll('#rootcontainer');
 if (rootcontainer.length) {
@@ -98,23 +115,25 @@ if (rootcontainer.length) {
   }
 
   async function postGetContributorID(owner, repo, issue_id, contributor_name) {
-   const res = await superagent
-     .post('http://localhost:4000/graphql')
-     .send(
-       //{ query: '{ name: 'Manny', species: 'cat' }' }
-       //{ query: '{ newPullRequest(pr_id: "first", contributorId: "1", side: 1) { vote_code } }' }
-       //{ query: '{ getVote(pr_id: "default", contributorId: 1) {side} }' }
-       //{ query: '{ getVoteAll(pr_id: "default") { vote_code } }' }
-       //{ query: `{ getVoteEverything }` }
-       { query: `{ getContributorID(owner: "${owner}", repo: "${repo}", pr_id: "${issue_id}", contributor_name: "${contributor_name}") }` }
-       //{ query: '{ setVote(pr_id: "default" contributorId: "2", side: 1 ) { vote_code }' }
-     ) // sends a JSON post body
-     .set('accept', 'json')
-     //.end((err, res) => {
-       // Calling the end function will send the request
-     //});
-   const json = JSON.parse(res.text)
-   return json.data.getContributorID
+    const res = await superagent
+      .post('http://localhost:4000/graphql')
+      .send(
+        //{ query: '{ name: 'Manny', species: 'cat' }' }
+        //{ query: '{ newPullRequest(pr_id: "first", contributorId: "1", side: 1) { vote_code } }' }
+        //{ query: '{ getVote(pr_id: "default", contributorId: 1) {side} }' }
+        //{ query: '{ getVoteAll(pr_id: "default") { vote_code } }' }
+        //{ query: `{ getVoteEverything }` }
+        {
+          query: `{ getContributorID(owner: "${owner}", repo: "${repo}", pr_id: "${issue_id}", contributor_name: "${contributor_name}") }`
+        }
+        //{ query: '{ setVote(pr_id: "default" contributorId: "2", side: 1 ) { vote_code }' }
+      ) // sends a JSON post body
+      .set('accept', 'json');
+    //.end((err, res) => {
+    // Calling the end function will send the request
+    //});
+    const json = JSON.parse(res.text);
+    return json.data.getContributorID;
   }
 
   async function postGetPRvoteStatus(owner, repo, issue_id, contributor_id, side) {
@@ -262,17 +281,14 @@ if (rootcontainer.length) {
     const isRepoTurboSrcToken = res_get_repo_status['body']['data']['getRepoStatus'];
     //contributor_name =  authContributor.getAuthContributor();
     let getFromStorageContributorName = keys =>
-    new Promise((resolve, reject) => chrome.storage.local.get(['contributor_name'], result => resolve(result.contributor_name)));
-    contributor_name = await getFromStorageContributorName()
-    console.log("authcontributors")
-    console.log(contributor_name)
-    contributor_id = await postGetContributorID(
-      user,
-      repo,
-      issue_id,
-      contributor_name,
-    )
-    const res_get_authorized_contributor =  await get_authorized_contributor(contributor_id, repo_id);
+      new Promise((resolve, reject) =>
+        chrome.storage.local.get(['contributor_name'], result => resolve(result.contributor_name))
+      );
+    contributor_name = await getFromStorageContributorName();
+    console.log('authcontributors');
+    console.log(contributor_name);
+    contributor_id = await postGetContributorID(user, repo, issue_id, contributor_name);
+    const res_get_authorized_contributor = await get_authorized_contributor(contributor_id, repo_id);
     const isAuthorizedContributor = res_get_authorized_contributor['body']['data']['getAuthorizedContributor'];
 
     console.log('isAuthorizedContributor: ' + isAuthorizedContributor);
@@ -291,9 +307,9 @@ if (rootcontainer.length) {
               repo: repo,
               issueID: issue_id,
               contributorName: contributor_name,
-              background: "white",
-              dynamicBool: true,
-            }
+              background: 'white',
+              dynamicBool: true
+            };
           }
 
           componentDidMount() {
@@ -464,8 +480,8 @@ if (rootcontainer.length) {
               repo: repo,
               issueID: issue_id,
               contributorName: contributor_name,
-              votes: ["0.0", "0.0"]
-            }
+              votes: ['0.0', '0.0']
+            };
           }
 
           componentDidMount() {
@@ -588,17 +604,14 @@ if (rootcontainer.length) {
         // Get contributor_id from chain web wallet extension
 
         let getFromStorageContributorName = keys =>
-        new Promise((resolve, reject) => chrome.storage.local.get(['contributor_name'], result => resolve(result.contributor_name)));
+          new Promise((resolve, reject) =>
+            chrome.storage.local.get(['contributor_name'], result => resolve(result.contributor_name))
+          );
         contributor_name = await getFromStorageContributorName();
-        console.log("authcontributors")
-        console.log(contributor_name)
-        contributor_id = await postGetContributorID(
-          user,
-          repo,
-          issue_id,
-          contributor_name,
-        )
-        var html
+        console.log('authcontributors');
+        console.log(contributor_name);
+        contributor_id = await postGetContributorID(user, repo, issue_id, contributor_name);
+        var html;
         for (var i = startIndex; i < containerItems.length; i++) {
           issue_id = containerItems[i].getAttribute('id');
           side = 'NA';


### PR DESCRIPTION
## All tests passing for Demo.
![Screen Shot 2022-06-28 at 3 20 03 PM](https://user-images.githubusercontent.com/75996017/176267817-05efad1b-9f62-46f2-a4bd-0854c7c07fe9.png)
![Screen Shot 2022-06-28 at 3 20 08 PM](https://user-images.githubusercontent.com/75996017/176267832-789ec7d7-33f2-4a50-b744-d31a98a4fab1.png)

# Key changes
1. Auth functionality added to Inject.js line 42.

2. In Inject.js contributor_id or name is no longer defined by postGetContributorId()... calls to the server. 

3. They are only got from Chrome storage where they were set from the web app's Home page. Lines 274-289 in Inject.js are the key changes.

4. A utility function getFromStorage is employed to do this. Inject.js line 283



