### PR TITLE
slight delay on token amount for accurate response

### DIFF
--- a/src/Components/Home.js
+++ b/src/Components/Home.js
@@ -40,7 +40,9 @@ export default function Home() {
         .then(res => useCommas(res.amount))
         .then(tokens => setTokenAmount(tokens));
     };
-    getTokenAmount();
+    setTimeout(()=>{
+      getTokenAmount()
+    }, 500)
   });
 
   if(owner === 'none' && repo === 'none') {


### PR DESCRIPTION
A time out of 500 ms is applied to the getContributorToken amount. This results in a minor delay of the token amount but prevents it from saying you have no vote power in a repo in which you do and needing to exit/enter the extension.